### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,7 +2601,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tool-cli"
-version = "0.1.20"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tool-cli"
 description = "`tool-cli` implements a CLI tool for managing MCP tools."
-version = "0.1.20"
+version = "0.2.0"
 edition = "2024"
 authors = ["Steve Akinyemi"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump minor version from 0.1.20 to 0.2.0 for new release
- Includes multiple features and improvements since the last release
- Prepares the package for publishing to crates.io

## Changes
This release includes the following changes since v0.1.20:

**Features:**
- feat(auth): add explicit token flag to publish and whoami commands
- feat(cli): add JSON syntax highlighting for tool call output

**Refactoring:**
- refactor(cli): standardize confirm prompts and output formatting
- refactor(cli): simplify search output formatting

**Documentation:**
- docs: update demo video in readme

**Version Bump:**
- Updated version in Cargo.toml from 0.1.20 to 0.2.0
- Updated Cargo.lock to reflect new version

## Test Plan
- [x] Run `cargo build --all` - compilation successful
- [x] Run `cargo check --all` - no issues
- [x] Run `cargo test --all` - 148 tests passed
- [x] Run `cargo clippy --all` - no warnings