### PR TITLE
feat(cli): add host filter to host list command

### DIFF
--- a/lib/commands.rs
+++ b/lib/commands.rs
@@ -985,7 +985,10 @@ pub enum HostCommand {
 
     /// List supported hosts and their status.
     #[command(alias = "l")]
-    List,
+    List {
+        /// Show tools for a specific host.
+        host: Option<String>,
+    },
 
     /// Preview the MCP config that would be generated.
     #[command(alias = "p", after_help = HOST_PREVIEW_EXAMPLES)]


### PR DESCRIPTION
## Summary
This PR enhances the `tool host list` command to accept an optional host argument for filtering output to a specific host's tools.

- Adds optional host parameter to filter list output to a single host
- Maintains backward compatibility with existing no-arg behavior
- Provides cleaner output for checking tools on specific MCP hosts
- Useful when users want to quickly see what's installed on one host without scrolling through all hosts

## Changes
- Modified `HostCommand::List` enum variant in lib/commands.rs to include optional `host: Option<String>` field
- Updated `host_list` function signature to accept `host_name: Option<&str>` parameter
- Added early return logic for single-host display with formatted output
- Implemented both normal and concise output modes for single-host view:
  - Normal mode: Shows host name with green checkmark, bulleted tool list, or "No tools installed" message
  - Concise mode: Tab-separated tool names with `#tool` header
- Updated handler match arm to pass host parameter using `.as_deref()`

## Test Plan
- Run `tool host list` to verify all hosts still display correctly (backward compatibility)
- Run `tool host list claude-desktop` to see tools for a host with installed tools
- Run `tool host list cursor` to see output for a host with no tools
- Run `tool host list --concise claude-desktop` to verify concise mode formatting
- Verify invalid host names produce appropriate error messages